### PR TITLE
🌟 feat: 로그인 후 보이는 숲 상세 조회 페이지 구현

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 const email = ref('')
 const password = ref('')
+const router = useRouter()
 
 const handleLogin = async (e) => {
   e.preventDefault()
@@ -33,6 +35,31 @@ const handleLogin = async (e) => {
 
     // 유저 닉네임 저장
     localStorage.setItem("userNickname", data.userNickname);
+
+    const token = localStorage.getItem('accessToken');
+    const authToken = `Bearer ${token}`;
+    console.log(authToken);
+
+    // 숲 정보 가져오기
+    const forestResponse = await fetch('http://localhost:8080/myforest', {
+      method: 'GET',
+      headers: {
+        Authorization: authToken,
+      }
+    })
+
+    if (!forestResponse.ok) {
+      throw new Error('숲 정보 불러오기 실패')
+    }
+
+    const forestData = await forestResponse.json()
+    const forestId = forestData[0]?.id
+
+    if (!forestId) {
+      throw new Error('숲이 존재하지 않습니다.')
+    }
+
+    router.push(`/forest-detail/${forestId}`)
 
     // 페이지 이동 처리 필요(내 숲 상세 조회 페이지로 이동 필요)
   } catch (error) {

--- a/src/components/isPublicBadge.vue
+++ b/src/components/isPublicBadge.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="tooltip-wrapper">
+    <div class="badge" :class="{ public: isPublic }">
+      {{ isPublic ? "공개중" : "비공개" }}
+    </div>
+    <div class="tooltip">
+      공개 범위 설정
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  isPublic: {
+    type: [Boolean, Number],
+    required: true
+  }
+})
+</script>
+
+<style scoped>
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  z-index: 1; /* 배경보다 위, 아이템보다 아래 */
+}
+
+.badge {
+  background-color: #7e928e;
+  color: white;
+  border-radius: 16px;
+  padding: 4px 12px;
+  font-size: 14px;
+  cursor: default;
+}
+
+.badge.public {
+  background-color: #6a9c7c;
+}
+
+.tooltip {
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  background-color: #ffffff;
+  color: #333;
+  font-size: 12px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 6px 10px;
+  position: absolute;
+  bottom: 120%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  transition: opacity 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  z-index: 2; /* 툴팁만 살짝 위에 */
+}
+
+.tooltip-wrapper:hover .tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,7 +8,6 @@ import ForestView from "../components/ForestView.vue";
 import MyItemView from "../components/MyItemView.vue";
 import Guestbook from "../components/GuestBook.vue";
 import Login from "@/components/Login.vue";
-import BackgroundImage from "@/components/BackgroundImage.vue";
 import Signup from "@/components/Signup.vue";
 import ForestDetail from "@/views/ForestDetail.vue"; 
 import BackgroundImage2 from "@/components/BackgroundImage2.vue";

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from "vue-router";
+
 import Main from "../views/Main.vue";
 import WriteDiary from "../components/WriteDiary.vue";
 import ViewDiary from "../components/ViewDiary.vue";
@@ -9,6 +10,7 @@ import Guestbook from "../components/GuestBook.vue";
 import Login from "@/components/Login.vue";
 import BackgroundImage from "@/components/BackgroundImage.vue";
 import Signup from "@/components/Signup.vue";
+import ForestDetail from "@/views/ForestDetail.vue"; 
 
 const router = createRouter({
   history: createWebHistory(),
@@ -52,6 +54,11 @@ const router = createRouter({
           name: "GuestBook",
           component: Guestbook,
         },
+        {
+          path: "forest-detail/:forestId", 
+          name: "ForestDetail",
+          component: ForestDetail,
+        },
       ],
     },
     {
@@ -63,7 +70,7 @@ const router = createRouter({
       path: "/signup",
       name: "SignUp",
       component: Signup,
-    }
+    },
   ],
 });
 

--- a/src/views/ForestDetail.vue
+++ b/src/views/ForestDetail.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import buttonIcon_6 from "../icons/edit_icon.png"
+import buttonIcon_7 from "../icons/External_icon.png"
+import buttonIcon_8 from "../icons/is_public_icon.png"
+
+const currentView = ref('background')
+const forestData = ref(null)
+const showTooltip = ref(false)
+
+const route = useRoute()
+const router = useRouter()
+
+onMounted(async () => {
+  const token = localStorage.getItem('accessToken')
+
+  let forestId = route.params.forestId
+
+  if (!forestId) {
+    try {
+      const res = await fetch('http://localhost:8080/myforest', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      })
+
+      if (!res.ok) throw new Error('myforest 요청 실패')
+
+      const forestList = await res.json()
+
+      if (!forestList.length) {
+        alert('소유한 숲이 없습니다.')
+        return
+      }
+
+      forestId = forestList[0].id
+      router.replace(`/forest-detail/${forestId}`)
+      return
+    } catch (err) {
+      console.error('myforest 호출 실패:', err)
+    }
+  } else {
+    try {
+      const response = await fetch(`http://localhost:8080/detail/${forestId}`, {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      })
+
+      if (!response.ok) throw new Error('detail 요청 실패')
+      forestData.value = await response.json()
+      console.log('forestData:', forestData.value)
+    } catch (error) {
+      console.error('숲 정보 불러오기 실패:', error)
+    }
+  }
+})
+
+const togglePublic = async () => {
+  if (!(forestData.value && forestData.value.length)) return;
+  const forestId = route.params.forestId;
+  const token = localStorage.getItem('accessToken');
+  console.log('token:', token);
+  try {
+    const res = await fetch(`http://localhost:8080/public/${forestId}`, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+    const text = await res.text();
+    console.log('PATCH status:', res.status, 'body:', text);
+    if (!res.ok) throw new Error('공개여부 변경 실패');
+    forestData.value[0].isPublic = !forestData.value[0].isPublic;
+  } catch (err) {
+    alert('공개여부 변경에 실패했습니다.');
+    console.error(err);
+  }
+}
+</script>
+
+<template>
+  <div class="container1">
+    <div class="main-area1">
+      <div class="icons">
+        <img :src="buttonIcon_6" class="btn-img" />
+        <img :src="buttonIcon_7" class="btn-img" />
+        <img
+          :src="buttonIcon_8"
+          class="btn-img"
+          @mouseenter="showTooltip = true"
+          @mouseleave="showTooltip = false"
+          @click="togglePublic"
+          style="cursor:pointer;"
+        />
+        <div v-if="showTooltip" class="tooltip">
+          <div class="tooltip-title">공개 범위 설정</div>
+            <div class="tooltip-status" 
+              :class="forestData && forestData.length && forestData[0].isPublic ? 'public' : 'private'">
+              {{ forestData && forestData.length && forestData[0].isPublic ? '공개중' : '비공개' }}
+            </div>
+          </div>
+        </div>
+      <!-- 정원 -->
+      <div v-if="forestData && forestData.length" class="forest-container">
+        <!-- 정중앙 텍스트 -->
+        <div class="background-container" :style="{ backgroundImage: `url(${forestData[0].backgroundImageUrl})` }">
+          <div class="forest-title">
+            <h1>{{ forestData[0].name }}</h1>
+          </div>
+          <div
+            v-for="item in forestData[0].placementList"
+            :key="item.placementId"
+            class="item"
+            :style="{
+              left: `${item.placementPositionX * 100}px`,
+              top: `${item.placementPositionY * 100}px`
+            }"
+          >
+            <img :src="item.itemImageUrl" :alt="item.itemName" class="item-image" />
+          </div>
+        </div>
+      </div>
+
+      <div v-else>
+        <p>데이터 불러오는 중...</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.container1 {
+  padding: 20px;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  position: relative;
+}
+
+.main-area1 {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.forest-container {
+  width: 100%;
+  max-width: 1200px;
+  position: relative;
+}
+
+.background-container {
+  width: 80%;
+  height: 600px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  margin: 0 auto;
+  position: relative;
+}
+
+.item {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+.item-image {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+  transition: transform 0.3s ease;
+}
+
+.item-image:hover {
+  transform: scale(1.1);
+}
+
+.icons {
+  position: absolute;
+  top: 12.83%;
+  left: 5.07%;
+  display: flex;
+  gap: 16px;
+  z-index: 10;
+}
+
+.btn-img {
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.forest-title {
+  position: absolute;
+  left: 50%;
+  top: calc(50% - 440px);
+  transform: translateX(-50%);
+  z-index: 5;
+  pointer-events: none;
+}
+
+.forest-title h1 {
+  color: white;
+  font-size: 36px;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  margin-top: 0px;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 50px;
+  left: 87%;
+  transform: translateX(-50%);
+  background: rgba(240, 248, 240, 0.95);
+  opacity: 0.7;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  padding: 12px 24px 16px 24px;
+  min-width: 180px;
+  z-index: 100;
+  text-align: center;
+  font-size: 18px;
+  color: #333;
+  pointer-events: none;
+}
+
+/* 꼬리(arrow) 추가 */
+.tooltip::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -16px; /* 꼬리 길이만큼 조정 */
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 14px solid transparent;
+  border-right: 14px solid transparent;
+  border-top: 16px solid rgba(240, 248, 240, 0.95); /* 툴팁 배경색과 동일 */
+}
+
+.tooltip-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.tooltip-status {
+  font-size: 15px;
+  background: #bfcfc2;
+  color: #fff;
+  border-radius: 10px;
+  padding: 2px 12px;
+  display: inline-block;
+}
+.tooltip-status.public {
+  background: rgba(11, 87, 138, 0.33); /* #0B578A 44% */
+}
+
+.tooltip-status.private {
+  background: rgba(255, 10, 38, 0.33); /* #FF0A26 44% */
+}
+</style>


### PR DESCRIPTION
## 🧩 이슈 번호 
- 관련 이슈번호 #13 
- close #이슈번호

## ✅ 작업 사항
<br>
로그인 이후 보여지는 숲 상세 조회 페이지 구현<br>
백엔드에서 개발한 숲 상세보기 결과를 S3 서버 주소를 이용하여 이미지로 띄웠음<br>
눈 모양 아이콘에 마우스 가져다 대면 해당 숲의 공개 여부 상태가 툴팁창으로 뜸<br>

## 📸 스크린샷 (선택)
<br>
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/7e353ba2-59e5-46d8-9b1d-ad66a87519d5" />

## 👩‍💻 공유 포인트 및 논의 사항
개발이 완료되지 않은 부분
1. 눈 모양 아이콘을 눌렀을 때 patch 요청을 보내 공개 여부 상태를 변경하는 것<br>
2. 공개 여부가 비공개일 때 눈 모양 아이콘이 '눈을 감은 상태'로 보이는 것